### PR TITLE
adds package management via packrat

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,0 +1,3 @@
+#### -- Packrat Autoloader (version 0.5.0-26) -- ####
+source("packrat/init.R")
+#### -- End Packrat Autoloader -- ####

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ vignettes/*.html
 # ignore generated html tex files,
 *.html
 *.tex
- 
+
 
 # OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
 .httr-oauth
@@ -54,3 +54,8 @@ Backup of *.doc*
 # PowerPoint temporary
 ~$*.ppt*
 *.dcf
+
+# PackRat
+packrat/lib*/
+packrat/src*
+packrat/bundles*

--- a/packrat/init.R
+++ b/packrat/init.R
@@ -1,0 +1,226 @@
+local({
+
+  ## Helper function to get the path to the library directory for a
+  ## given packrat project.
+  getPackratLibDir <- function(projDir = NULL) {
+    path <- file.path("packrat", "lib", R.version$platform, getRversion())
+
+    if (!is.null(projDir)) {
+
+      ## Strip trailing slashes if necessary
+      projDir <- sub("/+$", "", projDir)
+
+      ## Only prepend path if different from current working dir
+      if (!identical(normalizePath(projDir), normalizePath(getwd())))
+        path <- file.path(projDir, path)
+    }
+
+    path
+  }
+
+  ## Ensure that we set the packrat library directory relative to the
+  ## project directory. Normally, this should be the working directory,
+  ## but we also use '.rs.getProjectDirectory()' if necessary (e.g. we're
+  ## rebuilding a project while within a separate directory)
+  libDir <- if (exists(".rs.getProjectDirectory"))
+    getPackratLibDir(.rs.getProjectDirectory())
+  else
+    getPackratLibDir()
+
+  ## Unload packrat in case it's loaded -- this ensures packrat _must_ be
+  ## loaded from the private library. Note that `requireNamespace` will
+  ## succeed if the package is already loaded, regardless of lib.loc!
+  if ("packrat" %in% loadedNamespaces())
+    try(unloadNamespace("packrat"), silent = TRUE)
+
+  if (suppressWarnings(requireNamespace("packrat", quietly = TRUE, lib.loc = libDir))) {
+
+    # Check 'print.banner.on.startup' -- when NA and RStudio, don't print
+    print.banner <- packrat::get_opts("print.banner.on.startup")
+    if (print.banner == "auto" && is.na(Sys.getenv("RSTUDIO", unset = NA))) {
+      print.banner <- TRUE
+    } else {
+      print.banner <- FALSE
+    }
+    return(packrat::on(print.banner = print.banner))
+  }
+
+  ## Escape hatch to allow RStudio to handle bootstrapping. This
+  ## enables RStudio to provide print output when automagically
+  ## restoring a project from a bundle on load.
+  if (!is.na(Sys.getenv("RSTUDIO", unset = NA)) &&
+      is.na(Sys.getenv("RSTUDIO_PACKRAT_BOOTSTRAP", unset = NA))) {
+    Sys.setenv("RSTUDIO_PACKRAT_BOOTSTRAP" = "1")
+    setHook("rstudio.sessionInit", function(...) {
+      # Ensure that, on sourcing 'packrat/init.R', we are
+      # within the project root directory
+      if (exists(".rs.getProjectDirectory")) {
+        owd <- getwd()
+        setwd(.rs.getProjectDirectory())
+        on.exit(setwd(owd), add = TRUE)
+      }
+      source("packrat/init.R")
+    })
+    return(invisible(NULL))
+  }
+
+  ## Bootstrapping -- only performed in interactive contexts,
+  ## or when explicitly asked for on the command line
+  if (interactive() || "--bootstrap-packrat" %in% commandArgs(TRUE)) {
+
+    needsRestore <- "--bootstrap-packrat" %in% commandArgs(TRUE)
+
+    message("Packrat is not installed in the local library -- ",
+            "attempting to bootstrap an installation...")
+
+    ## We need utils for the following to succeed -- there are calls to functions
+    ## in 'restore' that are contained within utils. utils gets loaded at the
+    ## end of start-up anyhow, so this should be fine
+    library("utils", character.only = TRUE)
+
+    ## Install packrat into local project library
+    packratSrcPath <- list.files(full.names = TRUE,
+                                 file.path("packrat", "src", "packrat")
+    )
+
+    ## No packrat tarballs available locally -- try some other means of installation
+    if (!length(packratSrcPath)) {
+
+      message("> No source tarball of packrat available locally")
+
+      ## There are no packrat sources available -- try using a version of
+      ## packrat installed in the user library to bootstrap
+      if (requireNamespace("packrat", quietly = TRUE) && packageVersion("packrat") >= "0.2.0.99") {
+        message("> Using user-library packrat (",
+                packageVersion("packrat"),
+                ") to bootstrap this project")
+      }
+
+      ## Couldn't find a user-local packrat -- try finding and using devtools
+      ## to install
+      else if (requireNamespace("devtools", quietly = TRUE)) {
+        message("> Attempting to use devtools::install_github to install ",
+                "a temporary version of packrat")
+        library(stats) ## for setNames
+        devtools::install_github("rstudio/packrat")
+      }
+
+      ## Try downloading packrat from CRAN if available
+      else if ("packrat" %in% rownames(available.packages())) {
+        message("> Installing packrat from CRAN")
+        install.packages("packrat")
+      }
+
+      ## Fail -- couldn't find an appropriate means of installing packrat
+      else {
+        stop("Could not automatically bootstrap packrat -- try running ",
+             "\"'install.packages('devtools'); devtools::install_github('rstudio/packrat')\"",
+             "and restarting R to bootstrap packrat.")
+      }
+
+      # Restore the project, unload the temporary packrat, and load the private packrat
+      if (needsRestore)
+        packrat::restore(prompt = FALSE, restart = TRUE)
+
+      ## This code path only reached if we didn't restart earlier
+      unloadNamespace("packrat")
+      requireNamespace("packrat", lib.loc = libDir, quietly = TRUE)
+      return(packrat::on())
+
+    }
+
+    ## Multiple packrat tarballs available locally -- try to choose one
+    ## TODO: read lock file and infer most appropriate from there; low priority because
+    ## after bootstrapping packrat a restore should do the right thing
+    if (length(packratSrcPath) > 1) {
+      warning("Multiple versions of packrat available in the source directory;",
+              "using packrat source:\n- ", shQuote(packratSrcPath))
+      packratSrcPath <- packratSrcPath[[1]]
+    }
+
+
+    lib <- file.path("packrat", "lib", R.version$platform, getRversion())
+    if (!file.exists(lib)) {
+      dir.create(lib, recursive = TRUE)
+    }
+
+    message("> Installing packrat into project private library:")
+    message("- ", shQuote(lib))
+
+    surround <- function(x, with) {
+      if (!length(x)) return(character())
+      paste0(with, x, with)
+    }
+
+
+    ## Invoke install.packages() in clean R session
+    peq <- function(x, y) paste(x, y, sep = " = ")
+    installArgs <- c(
+      peq("pkgs", surround(packratSrcPath, with = "'")),
+      peq("lib", surround(lib, with = "'")),
+      peq("repos", "NULL"),
+      peq("type", surround("source", with = "'"))
+    )
+
+    fmt <- "utils::install.packages(%s)"
+    installCmd <- sprintf(fmt, paste(installArgs, collapse = ", "))
+
+    ## Write script to file (avoid issues with command line quoting
+    ## on R 3.4.3)
+    installFile <- tempfile("packrat-bootstrap", fileext = ".R")
+    writeLines(installCmd, con = installFile)
+    on.exit(unlink(installFile), add = TRUE)
+
+    fullCmd <- paste(
+      surround(file.path(R.home("bin"), "R"), with = "\""),
+      "--vanilla",
+      "--slave",
+      "-f",
+      surround(installFile, with = "\"")
+    )
+    system(fullCmd)
+
+    ## Tag the installed packrat so we know it's managed by packrat
+    ## TODO: should this be taking information from the lockfile? this is a bit awkward
+    ## because we're taking an un-annotated packrat source tarball and simply assuming it's now
+    ## an 'installed from source' version
+
+    ## -- InstallAgent -- ##
+    installAgent <- "InstallAgent: packrat 0.5.0-26"
+
+    ## -- InstallSource -- ##
+    installSource <- "InstallSource: source"
+
+    packratDescPath <- file.path(lib, "packrat", "DESCRIPTION")
+    DESCRIPTION <- readLines(packratDescPath)
+    DESCRIPTION <- c(DESCRIPTION, installAgent, installSource)
+    cat(DESCRIPTION, file = packratDescPath, sep = "\n")
+
+    # Otherwise, continue on as normal
+    message("> Attaching packrat")
+    library("packrat", character.only = TRUE, lib.loc = lib)
+
+    message("> Restoring library")
+    if (needsRestore)
+      packrat::restore(prompt = FALSE, restart = FALSE)
+
+    # If the environment allows us to restart, do so with a call to restore
+    restart <- getOption("restart")
+    if (!is.null(restart)) {
+      message("> Packrat bootstrap successfully completed. ",
+              "Restarting R and entering packrat mode...")
+      return(restart())
+    }
+
+    # Callers (source-erers) can define this hidden variable to make sure we don't enter packrat mode
+    # Primarily useful for testing
+    if (!exists(".__DONT_ENTER_PACKRAT_MODE__.") && interactive()) {
+      message("> Packrat bootstrap successfully completed. Entering packrat mode...")
+      packrat::on()
+    }
+
+    Sys.unsetenv("RSTUDIO_PACKRAT_BOOTSTRAP")
+
+  }
+
+})

--- a/packrat/init.R
+++ b/packrat/init.R
@@ -186,7 +186,7 @@ local({
     ## an 'installed from source' version
 
     ## -- InstallAgent -- ##
-    installAgent <- "InstallAgent: packrat 0.5.0-26"
+    installAgent <- "InstallAgent: packrat 0.5.0"
 
     ## -- InstallSource -- ##
     installSource <- "InstallSource: source"

--- a/packrat/packrat.lock
+++ b/packrat/packrat.lock
@@ -1,0 +1,710 @@
+PackratFormat: 1.4
+PackratVersion: 0.5.0.26
+RVersion: 3.6.3
+Repos: CRAN=https://cran.rstudio.com/
+
+Package: BH
+Source: CRAN
+Version: 1.72.0-3
+Hash: fc53be86f0b712d3de03fef95893d710
+
+Package: DBI
+Source: CRAN
+Version: 1.1.0
+Hash: d1075050684753e939c45775617c8f38
+
+Package: MASS
+Source: CRAN
+Version: 7.3-51.5
+Hash: be4bb419f1da59af6a9962ea3706eb05
+
+Package: Matrix
+Source: CRAN
+Version: 1.2-18
+Hash: 54974505e2addac3ec63f9d4bf8ff98a
+Requires: lattice
+
+Package: R6
+Source: CRAN
+Version: 2.4.1
+Hash: b488861d8c3dfac497e041ec911df9fb
+
+Package: RColorBrewer
+Source: CRAN
+Version: 1.1-2
+Hash: c0d56cd15034f395874c870141870c25
+
+Package: Rcpp
+Source: CRAN
+Version: 1.0.4.6
+Hash: 8b95553bc32a59321b8981aa02bfbf72
+
+Package: TTR
+Source: CRAN
+Version: 0.23-6
+Hash: ecd99f4703f96b3da329010465aaddde
+Requires: curl, xts, zoo
+
+Package: XML
+Source: CRAN
+Version: 3.99-0.3
+Hash: 575c7de7d478a357a378bbf2ae7dc460
+
+Package: askpass
+Source: CRAN
+Version: 1.1
+Hash: 6f6c430e3cd0dd7d48f447700f4d7e7f
+Requires: sys
+
+Package: assertthat
+Source: CRAN
+Version: 0.2.1
+Hash: 622be49032fe50bd42e96aaef613e209
+
+Package: backports
+Source: CRAN
+Version: 1.1.6
+Hash: 9bcc452d2494e85b970cdcc2889932ff
+
+Package: base64enc
+Source: CRAN
+Version: 0.1-3
+Hash: c590d29e555926af053055e23ee79efb
+
+Package: broom
+Source: CRAN
+Version: 0.5.6
+Hash: 837e20e17692b6d1cc0383e8cbbd1fc1
+Requires: backports, dplyr, generics, nlme, purrr, reshape2, stringr,
+    tibble, tidyr
+
+Package: callr
+Source: CRAN
+Version: 3.4.3
+Hash: e9b50bc56e655025fde6f2f4b65154de
+Requires: R6, processx
+
+Package: cellranger
+Source: CRAN
+Version: 1.1.0
+Hash: be9d203e7849f73818b36f93e9273c2c
+Requires: rematch, tibble
+
+Package: cli
+Source: CRAN
+Version: 2.0.2
+Hash: 6fc0b39f0fdbe3a025062807019e1180
+Requires: assertthat, crayon, fansi, glue
+
+Package: clipr
+Source: CRAN
+Version: 0.7.0
+Hash: 30cdec6c8cc62c80c485e6bdd0c02b05
+
+Package: colorspace
+Source: CRAN
+Version: 1.4-1
+Hash: 60a56e9998b8b58ee378db3dc91b27a5
+
+Package: crayon
+Source: CRAN
+Version: 1.3.4
+Hash: ff2840dd9b0d563fc80377a5a45510cd
+
+Package: crosstalk
+Source: CRAN
+Version: 1.1.0.1
+Hash: 0074e4967b2db46d003c5d23e4519306
+Requires: R6, htmltools, jsonlite, lazyeval
+
+Package: curl
+Source: CRAN
+Version: 4.3
+Hash: 3916ae5637dbaf5996dbde80ea92a047
+
+Package: data.table
+Source: CRAN
+Version: 1.12.8
+Hash: 283ad0e503ab521300c6d1d02e58d2ae
+
+Package: dbplyr
+Source: CRAN
+Version: 1.4.3
+Hash: 92ccb2003fb6c8087b5b979b2ff00cdb
+Requires: DBI, R6, assertthat, dplyr, glue, lifecycle, purrr, rlang,
+    tibble, tidyselect
+
+Package: desc
+Source: CRAN
+Version: 1.2.0
+Hash: a0a3ca939997679a52816bae4ed6aaae
+Requires: R6, assertthat, crayon, rprojroot
+
+Package: digest
+Source: CRAN
+Version: 0.6.25
+Hash: ec0a673866797c8c1fc1daa359fb4cad
+
+Package: dplyr
+Source: CRAN
+Version: 0.8.5
+Hash: ab9ffae1e3d7f8fbd2541a4795097977
+Requires: BH, R6, Rcpp, assertthat, ellipsis, glue, magrittr,
+    pkgconfig, plogr, rlang, tibble, tidyselect
+
+Package: ellipsis
+Source: CRAN
+Version: 0.3.0
+Hash: 30b58109e4d7c6184a9c2e32f9ae38c6
+Requires: rlang
+
+Package: evaluate
+Source: CRAN
+Version: 0.14
+Hash: 18306cc3bc1aec7b7360eea8a0eb0ee1
+
+Package: fansi
+Source: CRAN
+Version: 0.4.1
+Hash: fc0a252b8e427847d13e89f56ab4665e
+
+Package: farver
+Source: CRAN
+Version: 2.0.3
+Hash: 29a358c21cb8de2e424cbec6b6be6553
+
+Package: fastmap
+Source: CRAN
+Version: 1.0.1
+Hash: d272cd728e4095b3964181b44763f46c
+
+Package: forcats
+Source: CRAN
+Version: 0.5.0
+Hash: 6b130778caccc8e4e6cf498c76c84e7b
+Requires: ellipsis, magrittr, rlang, tibble
+
+Package: fs
+Source: CRAN
+Version: 1.4.1
+Hash: 6fc750e04d9d781e83d38c2f12958c80
+
+Package: generics
+Source: CRAN
+Version: 0.0.2
+Hash: 4aaf002dd434e8c854611c5d11a1d58e
+
+Package: ggplot2
+Source: CRAN
+Version: 3.3.0
+Hash: 0c4c6d28acdded392fce8d3d65f088de
+Requires: MASS, digest, glue, gtable, isoband, mgcv, rlang, scales,
+    tibble, withr
+
+Package: glue
+Source: CRAN
+Version: 1.4.0
+Hash: 21e4ea62a77239a9fc736d5b01338163
+
+Package: gtable
+Source: CRAN
+Version: 0.3.0
+Hash: a9e7b0666eb933a0cb36779240b4462e
+
+Package: haven
+Source: CRAN
+Version: 2.2.0
+Hash: 7d1e485a3083e66f7812f417dfa4c5c5
+Requires: Rcpp, forcats, hms, readr, rlang, tibble, tidyselect
+
+Package: hexbin
+Source: CRAN
+Version: 1.28.1
+Hash: 38f5e8c7439a986fee82ec0651c5eb39
+Requires: lattice
+
+Package: highcharter
+Source: CRAN
+Version: 0.7.0
+Hash: ef22a390c239c8244944e1736b2cff8f
+Requires: assertthat, broom, crosstalk, dplyr, htmltools, htmlwidgets,
+    igraph, jsonlite, lubridate, magrittr, purrr, quantmod, rlang,
+    rlist, stringr, tibble, tidyr, whisker, xts, yaml, zoo
+
+Package: highr
+Source: CRAN
+Version: 0.8
+Hash: 16aa2cc98d7b68c9d148c263c8dcdbcd
+
+Package: hms
+Source: CRAN
+Version: 0.5.3
+Hash: a0709e1b17b4bc1c27f5235177543e07
+Requires: pkgconfig, rlang, vctrs
+
+Package: htmltools
+Source: CRAN
+Version: 0.4.0
+Hash: 140efd8a56fc8404e81f7ac44731ce47
+Requires: Rcpp, digest, rlang
+
+Package: htmlwidgets
+Source: CRAN
+Version: 1.5.1
+Hash: 20e5cc02b795afc7322836c947b5aab2
+Requires: htmltools, jsonlite, yaml
+
+Package: httpuv
+Source: CRAN
+Version: 1.5.2
+Hash: b36f5b509d9c90201933b9c724347119
+Requires: BH, R6, Rcpp, later, promises
+
+Package: httr
+Source: CRAN
+Version: 1.4.1
+Hash: cc16de93eaabd3c6d0785cb8e6d059ab
+Requires: R6, curl, jsonlite, mime, openssl
+
+Package: igraph
+Source: CRAN
+Version: 1.2.5
+Hash: 56cd6b00fa9864975f6678b4d1a46b50
+Requires: Matrix, magrittr, pkgconfig
+
+Package: isoband
+Source: CRAN
+Version: 0.2.1
+Hash: d2c6d55af5a6470b2edef34d03d53068
+Requires: Rcpp, testthat
+
+Package: jsonlite
+Source: CRAN
+Version: 1.6.1
+Hash: bfde5e6072ca0f5226f49e457a9ba62d
+
+Package: knitr
+Source: CRAN
+Version: 1.28
+Hash: 408899ff6416ccf790182c95c8fa9c81
+Requires: evaluate, highr, markdown, stringr, xfun, yaml
+
+Package: labeling
+Source: CRAN
+Version: 0.3
+Hash: ecf589b42cd284b03a4beb9665482d3e
+
+Package: later
+Source: CRAN
+Version: 1.0.0
+Hash: 074cadbb9efd565454f7df6a2a56a672
+Requires: BH, Rcpp, rlang
+
+Package: lattice
+Source: CRAN
+Version: 0.20-38
+Hash: 45211081d39bb6d5a89fd789105901aa
+
+Package: lazyeval
+Source: CRAN
+Version: 0.2.2
+Hash: 563563691bea3cde6945a98996d7c166
+
+Package: lifecycle
+Source: CRAN
+Version: 0.2.0
+Hash: df8649860c43571aab68cc73a2a02807
+Requires: glue, rlang
+
+Package: lubridate
+Source: CRAN
+Version: 1.7.8
+Hash: ffe401bdcb9ccaea3d41a08f482a3aad
+Requires: Rcpp, generics
+
+Package: magrittr
+Source: CRAN
+Version: 1.5
+Hash: bdc4d48c3135e8f3b399536ddf160df4
+
+Package: markdown
+Source: CRAN
+Version: 1.1
+Hash: 1b6a18fd395589425e338a47b999099f
+Requires: mime, xfun
+
+Package: mgcv
+Source: CRAN
+Version: 1.8-31
+Hash: d3857a1a1e5f3586c3db8d0dbe4cc528
+Requires: Matrix, nlme
+
+Package: mime
+Source: CRAN
+Version: 0.9
+Hash: f3388735b4ddea072aff3be44f7f4968
+
+Package: modelr
+Source: CRAN
+Version: 0.1.6
+Hash: c3a21c2516969374e8d88846d9fbe065
+Requires: broom, dplyr, magrittr, purrr, rlang, tibble, tidyr,
+    tidyselect
+
+Package: munsell
+Source: CRAN
+Version: 0.5.0
+Hash: 38d0efee9bb99bef143bde41c4ce715c
+Requires: colorspace
+
+Package: nlme
+Source: CRAN
+Version: 3.1-147
+Hash: b57b31ff0dc8d5e0917ee9cd05254f6f
+Requires: lattice
+
+Package: openssl
+Source: CRAN
+Version: 1.4.1
+Hash: b01fe6ae05ec2a30a777dc338af5bf69
+Requires: askpass
+
+Package: packrat
+Source: github
+Version: 0.5.0-26
+Hash: 40701e3fe34fa32b15ed3afbae775f33
+GithubRepo: packrat
+GithubUsername: rstudio
+GithubRef: master
+GithubSha1: 8753d425f363c420846fe05bcba05e5e9b080bb5
+
+Package: pillar
+Source: CRAN
+Version: 1.4.3
+Hash: 64ebcd61a33f2bd9059ffa8a323fd620
+Requires: cli, crayon, fansi, rlang, utf8, vctrs
+
+Package: pkgbuild
+Source: CRAN
+Version: 1.0.6
+Hash: f41de345bf0dda984cce64a7ea668ea4
+Requires: R6, callr, cli, crayon, desc, prettyunits, rprojroot, withr
+
+Package: pkgconfig
+Source: CRAN
+Version: 2.0.3
+Hash: 5ff5f2361851a49534c96caa2a8071c7
+
+Package: pkgload
+Source: CRAN
+Version: 1.0.2
+Hash: 41eb2db35be61f6f9e8864cf87a1ecb0
+Requires: desc, pkgbuild, rlang, rprojroot, rstudioapi, withr
+
+Package: plogr
+Source: CRAN
+Version: 0.2.0
+Hash: 81a8008a5e7858552503935f1abe48aa
+
+Package: plotly
+Source: CRAN
+Version: 4.9.2.1
+Hash: eeb9c83733cd3c9852c727b48678ce9a
+Requires: RColorBrewer, base64enc, crosstalk, data.table, digest,
+    dplyr, ggplot2, hexbin, htmltools, htmlwidgets, httr, jsonlite,
+    lazyeval, magrittr, promises, purrr, rlang, scales, tibble, tidyr,
+    viridisLite
+
+Package: plyr
+Source: CRAN
+Version: 1.8.6
+Hash: 0c83f38e28923acc988df91f1837f634
+Requires: Rcpp
+
+Package: praise
+Source: CRAN
+Version: 1.0.0
+Hash: 77da8f1df873a4b91e5c4a68fe2fb1b6
+
+Package: prettyunits
+Source: CRAN
+Version: 1.1.1
+Hash: 20669cd8bb8b3207f6371edf8cf510af
+
+Package: processx
+Source: CRAN
+Version: 3.4.2
+Hash: e1671b1ca2f6c66f29ffb2828e98dc02
+Requires: R6, ps
+
+Package: progress
+Source: CRAN
+Version: 1.2.2
+Hash: 209280eb751acf5899f7c69366e14bd3
+Requires: R6, crayon, hms, prettyunits
+
+Package: promises
+Source: CRAN
+Version: 1.1.0
+Hash: 3aad74d60d080359e7947b795cf53cf0
+Requires: R6, Rcpp, later, magrittr, rlang
+
+Package: ps
+Source: CRAN
+Version: 1.3.2
+Hash: 6e8ed574a4550ce4f72cdafa9227152b
+
+Package: purrr
+Source: CRAN
+Version: 0.3.4
+Hash: fb4c0edca61826ca0b5b33c828a7b276
+Requires: magrittr, rlang
+
+Package: quantmod
+Source: CRAN
+Version: 0.4.17
+Hash: 6aadbd45adc8116a95dc16ed3add2715
+Requires: TTR, curl, xts, zoo
+
+Package: readr
+Source: CRAN
+Version: 1.3.1
+Hash: 9265e661634ee2d5c89d93d5551fbc58
+Requires: BH, R6, Rcpp, clipr, crayon, hms, tibble
+
+Package: readxl
+Source: CRAN
+Version: 1.3.1
+Hash: ea27b2cd7e0e03266f819c5731d70333
+Requires: Rcpp, cellranger, progress, tibble
+
+Package: rematch
+Source: CRAN
+Version: 1.0.1
+Hash: ad4faf59e7611117ff165817074c50c7
+
+Package: reprex
+Source: CRAN
+Version: 0.3.0
+Hash: 2029355cb70894267c2c7557c79307fd
+Requires: callr, clipr, fs, rlang, rmarkdown, whisker, withr
+
+Package: reshape2
+Source: CRAN
+Version: 1.4.4
+Hash: 18ecb14c203e2963654dbc1b50f14030
+Requires: Rcpp, plyr, stringr
+
+Package: rhandsontable
+Source: CRAN
+Version: 0.3.7
+Hash: 684b6e2edd72ff7ed37b8ba1461b44b5
+Requires: htmlwidgets, jsonlite, magrittr
+
+Package: rlang
+Source: CRAN
+Version: 0.4.5
+Hash: 99d62d0aaf54a9938784f4485efa9933
+
+Package: rlist
+Source: CRAN
+Version: 0.4.6.1
+Hash: 4900e17a86fa510778fd99079c905d5d
+Requires: XML, data.table, jsonlite, yaml
+
+Package: rmarkdown
+Source: CRAN
+Version: 2.1
+Hash: 8693e30146ce847a75c5eeff9a42b0d9
+Requires: base64enc, evaluate, htmltools, jsonlite, knitr, mime,
+    stringr, tinytex, xfun, yaml
+
+Package: rprojroot
+Source: CRAN
+Version: 1.3-2
+Hash: a25c3f70c166fb3fbabc410eb32b6366
+Requires: backports
+
+Package: rstudioapi
+Source: CRAN
+Version: 0.11
+Hash: f8674fe40760ccfc1bf3e92da4c9f4d0
+
+Package: rvest
+Source: CRAN
+Version: 0.3.5
+Hash: 76dc42671d747a857ea344bc56cd5b51
+Requires: httr, magrittr, selectr, xml2
+
+Package: scales
+Source: CRAN
+Version: 1.1.0
+Hash: fa53af4e3ceba05fc79a31bde5962445
+Requires: R6, RColorBrewer, farver, labeling, lifecycle, munsell,
+    viridisLite
+
+Package: scico
+Source: CRAN
+Version: 1.1.0
+Hash: 60decb276b54f4b9d2d2efc76f97a06d
+
+Package: selectr
+Source: CRAN
+Version: 0.4-2
+Hash: b915e37654e476cbad2ceb063a2b8edb
+Requires: R6, stringr
+
+Package: shiny
+Source: CRAN
+Version: 1.4.0.2
+Hash: 42d22fabaa1b11b7b7e4a9f623b4641a
+Requires: R6, crayon, digest, fastmap, htmltools, httpuv, jsonlite,
+    later, mime, promises, rlang, sourcetools, xtable
+
+Package: shinyWidgets
+Source: CRAN
+Version: 0.5.1
+Hash: 94cf169fce3b79ae1301b787bb1cc276
+Requires: htmltools, jsonlite, scales, shiny
+
+Package: shinyjs
+Source: CRAN
+Version: 1.1
+Hash: 1998b94e4425bcc71539e897bceed880
+Requires: digest, htmltools, jsonlite, shiny
+
+Package: sourcetools
+Source: CRAN
+Version: 0.1.7
+Hash: d093478ac90064e670cd4bf1a99b47b6
+
+Package: stringi
+Source: CRAN
+Version: 1.4.6
+Hash: 076b0f115b37ca6d551ccff96b91114e
+
+Package: stringr
+Source: CRAN
+Version: 1.4.0
+Hash: 67da32dbb2a7a16f2ef124336358e54a
+Requires: glue, magrittr, stringi
+
+Package: sys
+Source: CRAN
+Version: 3.3
+Hash: d5a4afad9298f42aae77f6389713a066
+
+Package: testthat
+Source: CRAN
+Version: 2.3.2
+Hash: 5a3a20ddc31b2aa228dab6d29bd43948
+Requires: R6, cli, crayon, digest, ellipsis, evaluate, magrittr,
+    pkgload, praise, rlang, withr
+
+Package: tibble
+Source: CRAN
+Version: 3.0.1
+Hash: 00d3817b8530e9ce9b465aeef293a011
+Requires: cli, crayon, ellipsis, fansi, lifecycle, magrittr, pillar,
+    pkgconfig, rlang, vctrs
+
+Package: tidyext
+Source: github
+Version: 0.3.1
+Hash: 9ee4c076a8c4310158c57d0e0910998c
+Requires: dplyr, magrittr, purrr, rlang, scales, tibble, tidyr
+GithubRepo: tidyext
+GithubUsername: m-clark
+GithubRef: master
+GithubSha1: 28df8798e1b1a2f8a5613a84a8b5e96e5b18f2b5
+
+Package: tidyr
+Source: CRAN
+Version: 1.0.2
+Hash: 7183ff9a4d4c4680bd1e6f79086c6405
+Requires: Rcpp, dplyr, ellipsis, glue, lifecycle, magrittr, purrr,
+    rlang, stringi, tibble, tidyselect, vctrs
+
+Package: tidyselect
+Source: CRAN
+Version: 1.0.0
+Hash: 0ba21f624978533adf670338aa3f86b4
+Requires: ellipsis, glue, purrr, rlang, vctrs
+
+Package: tidyverse
+Source: CRAN
+Version: 1.3.0
+Hash: b909ba2b6349072c6376f95a816fe932
+Requires: broom, cli, crayon, dbplyr, dplyr, forcats, ggplot2, haven,
+    hms, httr, jsonlite, lubridate, magrittr, modelr, pillar, purrr,
+    readr, readxl, reprex, rlang, rstudioapi, rvest, stringr, tibble,
+    tidyr, xml2
+
+Package: tinytex
+Source: CRAN
+Version: 0.22
+Hash: 3caad813c309bf230229b9025ac0a28e
+Requires: xfun
+
+Package: utf8
+Source: CRAN
+Version: 1.1.4
+Hash: f3f97ce59092abc8ed3fd098a59e236c
+
+Package: vctrs
+Source: CRAN
+Version: 0.2.4
+Hash: e06451edcd80df3a07b71fe7f5d10739
+Requires: digest, ellipsis, glue, rlang
+
+Package: viridisLite
+Source: CRAN
+Version: 0.3.0
+Hash: 78bb072c4f9e729a283d4c40ec93f9c6
+
+Package: whisker
+Source: CRAN
+Version: 0.4
+Hash: 5b1ec05cd96c1e0c6048bab49abee3aa
+
+Package: withr
+Source: CRAN
+Version: 2.2.0
+Hash: 709a3da4deef928ab299f4ff52caf66b
+
+Package: writexl
+Source: CRAN
+Version: 1.2
+Hash: 08eca2a8129821f456bdca064edd0bcc
+
+Package: xfun
+Source: CRAN
+Version: 0.13
+Hash: 27ad2c3d9cc614cfb92e1bb51b62f5f6
+
+Package: xml2
+Source: CRAN
+Version: 1.3.1
+Hash: f4ec872df66ff6bc703cddde2958663d
+
+Package: xtable
+Source: CRAN
+Version: 1.8-4
+Hash: dc0d47261b678d26032363bebd050540
+
+Package: xts
+Source: CRAN
+Version: 0.12-0
+Hash: 44a97ea0592b91a5ba6851df01f5bb9f
+Requires: zoo
+
+Package: yaml
+Source: CRAN
+Version: 2.2.1
+Hash: 424bc11cc358f23187feaa7978628196
+
+Package: zoo
+Source: CRAN
+Version: 1.8-7
+Hash: d333d9408647b5fc153dc5817b3ad0fe
+Requires: lattice

--- a/packrat/packrat.opts
+++ b/packrat/packrat.opts
@@ -1,0 +1,19 @@
+auto.snapshot: FALSE
+use.cache: FALSE
+print.banner.on.startup: auto
+vcs.ignore.lib: TRUE
+vcs.ignore.src: FALSE
+external.packages: 
+local.repos: 
+load.external.packages.on.startup: TRUE
+ignored.packages: 
+ignored.directories:
+    data
+    inst
+quiet.package.installation: TRUE
+snapshot.recommended.packages: FALSE
+snapshot.fields:
+    Imports
+    Depends
+    LinkingTo
+symlink.system.packages: TRUE


### PR DESCRIPTION
## Description

This should not be merged. the following steps should be done from a user with a fully working project. I've still got an error pictured below:
<img width="907" alt="Screen Shot 2020-04-22 at 9 16 26 PM" src="https://user-images.githubusercontent.com/30823997/80048569-8d82ff00-84de-11ea-8ca7-7c114d09245f.png">

## Replicate this
Step 1
```
install.packages("devtools")
devtools::install_github("rstudio/packrat")
packrat::init()
packrat::snapshot()
```
Step 2
Add the following to the end of .gitignore
```
# PackRat
packrat/lib*/
packrat/src*
packrat/bundles*
```

More info on packrat [here](https://rstudio.github.io/packrat/commands.html)

### Main Functionality
`packrat::init()` Initializes the current working directory as a Packrat project.
When you want to manage the state of your private library, you can use the Packrat functions:

`packrat::snapshot()` Save the current state of your library.
`packrat::restore()` Restore the library state saved in the most recent snapshot.
`packrat::clean()` Remove unused packages from your library.
Share a Packrat project with bundle and unbundle:

`packrat::bundle()` Bundle a packrat project, for easy sharing.
`packrat::unbundle()` Unbundle a packrat project, generating a project directory with libraries restored.
Navigate projects with:

`packrat::on()` &  `packrat::off()` Toggle packrat mode on and off, for navigating between projects within a single R session.